### PR TITLE
set label linebreak mode byTruncatingMiddle

### DIFF
--- a/ResizingTokenField/Classes/Items/DefaultTokenCell.swift
+++ b/ResizingTokenField/Classes/Items/DefaultTokenCell.swift
@@ -43,8 +43,12 @@ class DefaultTokenCell: ResizingTokenFieldTokenCell {
         
         addSubview(titleLabel)
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.textAlignment = .center
         titleLabel.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
         titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
+        titleLabel.widthAnchor.constraint(equalTo: widthAnchor).isActive = true
+        
+        titleLabel.lineBreakMode = .byTruncatingMiddle
     }
     
     // MARK: - Configuration

--- a/ResizingTokenField/Classes/ResizingTokenField.swift
+++ b/ResizingTokenField/Classes/ResizingTokenField.swift
@@ -551,11 +551,20 @@ open class ResizingTokenField: UIView, UICollectionViewDataSource, UICollectionV
         case Constants.Identifier.tokenCell:
             if let token = viewModel.token(atIndexPath: indexPath) {
                 if let delegate = customCellDelegate {
-                    return CGSize(width: delegate.resizingTokenField(self, tokenCellWidthForToken: token),
+                    var width = delegate.resizingTokenField(self, tokenCellWidthForToken: token)
+                    if width > collectionView.frame.size.width {
+                        width = collectionView.frame.size.width - (2 * Constants.Default.defaultTokenLeftRightPadding)
+                    }
+                    
+                    return CGSize(width: width,
                                   height: itemHeight)
                 }
+                var size = viewModel.defaultTokenCellSize(forToken: token)
+                if size.width > collectionView.frame.size.width {
+                    size.width = collectionView.frame.size.width - (2 * Constants.Default.defaultTokenLeftRightPadding)
+                }
                 
-                return viewModel.defaultTokenCellSize(forToken: token)
+                return size
             }
         default:
             break


### PR DESCRIPTION
When the user enters a long text, the label size goes out of the screen. 